### PR TITLE
Fix small docs typo

### DIFF
--- a/examples/next-langchain/README.md
+++ b/examples/next-langchain/README.md
@@ -36,7 +36,7 @@ To run the example locally you need to:
 
 To learn more about LangChain, OpenAI, Next.js, and the AI SDK take a look at the following resources:
 
-- [AI SDK docs](https://ai-sdk.dev/docs) - learn mode about the AI SDK
+ - [AI SDK docs](https://ai-sdk.dev/docs) - learn more about the AI SDK
 - [Vercel AI Playground](https://ai-sdk.dev/playground) - compare and tune 20+ AI models side-by-side
 - [LangChain Documentation](https://js.langchain.com/docs) - learn about LangChain
 - [OpenAI Documentation](https://platform.openai.com/docs) - learn about OpenAI features and API.

--- a/examples/nuxt-openai/README.md
+++ b/examples/nuxt-openai/README.md
@@ -41,7 +41,7 @@ You can use different providers, such as `vercel` by modifying your `nuxt.config
 
 To learn more about OpenAI, Nuxt, and the AI SDK take a look at the following resources:
 
-- [AI SDK docs](https://ai-sdk.dev/docs) - learn mode about the AI SDK
+ - [AI SDK docs](https://ai-sdk.dev/docs) - learn more about the AI SDK
 - [Vercel AI Playground](https://ai-sdk.dev/playground) - compare and tune 20+ AI models side-by-side
 - [OpenAI Documentation](https://platform.openai.com/docs) - learn about OpenAI features and API.
 - [Nuxt Documentation](https://nuxt.com/docs) - learn about Nuxt features and API.

--- a/examples/solidstart-openai/README.md
+++ b/examples/solidstart-openai/README.md
@@ -41,7 +41,7 @@ By default, `npm run build` will generate a Node app that you can run with `npm 
 
 To learn more about OpenAI, Nuxt, and the AI SDK take a look at the following resources:
 
-- [AI SDK docs](https://ai-sdk.dev/docs) - learn mode about the AI SDK
+ - [AI SDK docs](https://ai-sdk.dev/docs) - learn more about the AI SDK
 - [Vercel AI Playground](https://ai-sdk.dev/playground) - compare and tune 20+ AI models side-by-side
 - [OpenAI Documentation](https://platform.openai.com/docs) - learn about OpenAI features and API.
 - [SolidStart Documentation](https://start.solidjs.com) - learn about SolidStart.


### PR DESCRIPTION
## Summary
- fix typos in example READMEs